### PR TITLE
Update bpftrace image

### DIFF
--- a/cryptnono/values.yaml
+++ b/cryptnono/values.yaml
@@ -1,7 +1,9 @@
 image:
-  # Pickup something recent from https://quay.io/repository/iovisor/bpftrace?tab=tags
   repository: quay.io/iovisor/bpftrace
-  tag: 1c295d899035aaded34d5861375051ec1add1d3a-vanilla_llvm12_clang_glibc2.23
+  # tag is set to something recent from:
+  # - https://github.com/iovisor/bpftrace/releases
+  # - https://quay.io/repository/iovisor/bpftrace?tab=tags
+  tag: v0.17.0-vanilla_llvm12_clang_glibc2.31
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
This new version seem to work, and while debugging an error that wen't away it would have been helpful knowing how the version of this image tied to the bpftrace version.