### PR TITLE
Add priorityClassName

### DIFF
--- a/cryptnono/templates/daemonset.yaml
+++ b/cryptnono/templates/daemonset.yaml
@@ -161,3 +161,6 @@ spec:
         - hostPath:
             path: /boot
           name: boot-host
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/cryptnono/values.yaml
+++ b/cryptnono/values.yaml
@@ -32,6 +32,9 @@ tolerations:
 
 affinity: {}
 
+# https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+priorityClassName: ""
+
 fetchKernelHeaders:
   resources: {}
   image:


### PR DESCRIPTION
Allows cryptnono pods to be given priority over other pods if node resources are limited

Related: https://github.com/jupyterhub/mybinder.org-deploy/pull/2814/files