### PR TITLE
Kill existing matching processes on startup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,62 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+#
+name: Test
+
+# Trigger the workflow on pushed tags or commits to main branch.
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r dev-requirements.txt
+          pip list
+
+      - name: Build image
+        run: |
+          docker build -t cryptono:test .
+
+      - name: Run image
+        run: |
+          docker run -d --name cryptono --rm --privileged --pid=host -v /usr/src:/usr/src:ro -v /sys:/sys:ro -v /lib/modules:/lib/modules:ro -v $PWD/example:/example cryptono:test /scripts/execwhacker.py --config /example/config.json --scan-existing 10
+          sleep 10
+          docker logs cryptono
+
+      - name: Build self-changing test binary
+        run: |
+          make
+        working-directory: tests/resources
+
+      - name: Run tests
+        run: |
+          python -mpytest -v tests/
+
+      - name: Get logs so we can check tests behaved correctly
+        run: |
+          docker logs cryptono

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cryptnono-test-self-changing-cmdline
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ FROM ubuntu:23.10
 
 RUN apt-get update --yes >/dev/null && \
     apt-get install --yes -qq \
-        python3 python3-ahocorasick python3-bpfcc \
+        python3 \
+        python3-ahocorasick \
+        python3-bpfcc \
+        python3-psutil \
         tini \
         bpftrace && \
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -128,11 +128,6 @@ detectors:
       enabled: true
 ```
 
-#### Caveats
-
-1. This only watches for *new* process executions - if you already have a process running,
-   `execwhacker` will not whack it.
-
 ## Development
 
 To develop `execwhacker` locally install the `apt-get` dependencies (or equivalent) from the [Dockerfile](./Dockerfile).

--- a/cryptnono/templates/daemonset.yaml
+++ b/cryptnono/templates/daemonset.yaml
@@ -53,9 +53,6 @@ spec:
             - mountPath: /sys
               name: sys
               readOnly: true
-            - mountPath: /proc
-              name: proc
-              readOnly: true
             - mountPath: /config
               name: config
               readOnly: true
@@ -145,9 +142,6 @@ spec:
         - hostPath:
             path: /lib/modules
           name: modules-host
-        - hostPath:
-            path: /proc
-          name: proc
         - hostPath:
             path: /sys
           name: sys

--- a/cryptnono/templates/daemonset.yaml
+++ b/cryptnono/templates/daemonset.yaml
@@ -53,6 +53,9 @@ spec:
             - mountPath: /sys
               name: sys
               readOnly: true
+            - mountPath: /proc
+              name: proc
+              readOnly: true
             - mountPath: /config
               name: config
               readOnly: true
@@ -142,6 +145,9 @@ spec:
         - hostPath:
             path: /lib/modules
           name: modules-host
+        - hostPath:
+            path: /proc
+          name: proc
         - hostPath:
             path: /sys
           name: sys

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 chartpress
+pytest

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -116,8 +116,13 @@ def process_event(
 
 
 def check_existing_processes(banned_strings_automaton, allowed_patterns, interval):
+    """
+    Scan all running processes for banned strings
+    
+    BPF only looks for new processes, this will find banned processes that were already
+    running, and any that might've been missed by BPF for unknown reasons.
+    """
     while True:
-        logging.info("Checking existing processes")
         count = 0
         for proc in process_iter():
             if proc.exe():
@@ -129,7 +134,7 @@ def check_existing_processes(banned_strings_automaton, allowed_patterns, interva
                     ProcessSource.SCAN,
                 ):
                     count += 1
-        logging.info(f"Killed {count} existing processes")
+        logging.info(f"action:summarise-existing-killed count:{count} source:{ProcessSource.SCAN.value}")
         time.sleep(interval)
 
 

--- a/tests/resources/Makefile
+++ b/tests/resources/Makefile
@@ -1,0 +1,2 @@
+cryptnono-test-self-changing-cmdline: cryptnono-test-self-changing-cmdline.c
+	$(CC) -o $@ $<

--- a/tests/resources/cryptnono-test-self-changing-cmdline.c
+++ b/tests/resources/cryptnono-test-self-changing-cmdline.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main (int argc, char* argv[])
+{
+    printf("pid: %i\n", getpid());
+    sleep(5);
+    snprintf(argv[0], strlen(argv[0]), "cryptnono.banned.string1");
+    // In the tests we set --scan-existing 10 seconds so this should be killed
+    // If it's not then we'll know because this will return 0
+    sleep(15);
+    return 0;
+}

--- a/tests/resources/cryptnono-test-self-changing-cmdline.c
+++ b/tests/resources/cryptnono-test-self-changing-cmdline.c
@@ -2,13 +2,26 @@
 #include <string.h>
 #include <unistd.h>
 
+/**
+ * This provides an executable to test whether execwhacker detects processes that
+ * were missed by BPF.
+ *
+ * execwhacker should be run with arguments `--config /example/config.json --scan-existing 10`
+ *
+ * This program should be compiled to an executable named `cryptnono-test-self-changing-cmdline`
+ * which means it should be allowed by execwhacker.
+ *
+ * Afger a few seconds the executable overwrites it's argv[0] to the banned string
+ * `cryptnono.banned.string1` which means it should be killed after a short while (less than 10
+ * seconds) by the non-BPF scanner.
+ *
+ * If not it will exit with code 0, and the test wrapper should report an error.
+ */
 int main (int argc, char* argv[])
 {
     printf("pid: %i\n", getpid());
     sleep(5);
     snprintf(argv[0], strlen(argv[0]), "cryptnono.banned.string1");
-    // In the tests we set --scan-existing 10 seconds so this should be killed
-    // If it's not then we'll know because this will return 0
     sleep(15);
     return 0;
 }

--- a/tests/resources/cryptnono-test-self-changing-cmdline.c
+++ b/tests/resources/cryptnono-test-self-changing-cmdline.c
@@ -11,7 +11,7 @@
  * This program should be compiled to an executable named `cryptnono-test-self-changing-cmdline`
  * which means it should be allowed by execwhacker.
  *
- * Afger a few seconds the executable overwrites it's argv[0] to the banned string
+ * After a few seconds the executable overwrites it's argv[0] to the banned string
  * `cryptnono.banned.string1` which means it should be killed after a short while (less than 10
  * seconds) by the non-BPF scanner.
  *

--- a/tests/test_cryptnono_container.py
+++ b/tests/test_cryptnono_container.py
@@ -1,0 +1,20 @@
+import os
+from subprocess import run
+import sys
+
+
+def test_allowed():
+    p = run([sys.executable, "-c", "print('allowed cryptnono.banned.string1')"])
+    assert p.returncode == 0
+
+
+def test_killed():
+    p = run([sys.executable, "-c", "print('cryptnono.banned.string1')"])
+    assert p.returncode == -9
+
+
+# Test the non-BPF psutil scanner by starting a safe process, and changing it's
+# cmdline to one that's banned
+def test_self_changing_killed():
+    p = run([os.path.join(os.path.dirname(__file__), "resources", "cryptnono-test-self-changing-cmdline")])
+    assert p.returncode == -9


### PR DESCRIPTION
I thought parsing `/proc/*/cmdline` was simpler than installing psutil.

I've only tested this in a VM (following https://github.com/yuvipanda/cryptnono/pull/10), not as a K8s container.

In one terminal run
```sh
sh -c 'sleep 1h; /bin/echo cryptnono.banned.string1'
```
In another run
```
sudo ./scripts/execwhacker.py --config example/config.json --debug
```