### PR TITLE
Add baseVersion to chartpress.yaml

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -13,6 +13,8 @@ charts:
     repo:
       git: yuvipanda/cryptnono
       published: https://yuvipanda.github.io/cryptnono
+    # Should be greater than last tag to ensure `helm show chart --devel` picks up dev versions
+    baseVersion: "0.3.1-0.dev"
     imagePrefix: quay.io/yuvipanda/
     images:
       fetch-kernel-headers:


### PR DESCRIPTION
https://github.com/jupyterhub/mybinder.org-deploy/blob/5f00aa3f4d90f69649b0c20af70210c71c44fcda/.github/workflows/watch-dependencies.yaml#L167-L172
should pickup dev charts, but this requires dev versions to be greater than the latest tag (current dev version after merging https://github.com/yuvipanda/cryptnono/pull/11 is `0.3.0-0.dev.git.87.h25d3642`)

Would be nice if chartpress had the option to automatically use `last-tag + 0.0.1`.... I might look at that in future.