### PR TITLE
Don't kill substring matches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -71,5 +71,6 @@ jobs:
           python -mpytest -v tests/
 
       - name: Get logs so we can check tests behaved correctly
+        if: always()
         run: |
           docker logs cryptono

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -67,6 +67,8 @@ def kill_if_needed(banned_strings_automaton, allowed_patterns, cmdline, pid, sou
                             f"action:spared pid:{pid} cmdline:{cmdline} matched:{b} allowed-by:{ap} source:{source.value}"
                         )
                     return
+            # Only kill if the banned string is a standalone "word",
+            # i.e. it's surrounded by whitespace, punctuation, etc.
             if (
                     re.search(r"\w" + re.escape(b), cmdline, re.IGNORECASE) or
                     re.search(re.escape(b) + r"\w", cmdline, re.IGNORECASE)

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -74,7 +74,7 @@ def kill_if_needed(banned_strings_automaton, allowed_patterns, cmdline, pid, sou
                     re.search(re.escape(b) + r"\w", cmdline, re.IGNORECASE)
             ):
                 logging.info(
-                    f"action:spared pid:{pid} cmdline:{cmdline} matched:{b} allowed-by:<is-substring> source:{source.value}"
+                    f"action:spared pid:{pid} cmdline:{cmdline} matched:{b} allowed-by:is-substring source:{source.value}"
                 )
                 return
             try:

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -67,6 +67,14 @@ def kill_if_needed(banned_strings_automaton, allowed_patterns, cmdline, pid, sou
                             f"action:spared pid:{pid} cmdline:{cmdline} matched:{b} allowed-by:{ap} source:{source.value}"
                         )
                     return
+            if (
+                    re.search(r"\w" + re.escape(b), cmdline, re.IGNORECASE) or
+                    re.search(re.escape(b) + r"\w", cmdline, re.IGNORECASE)
+            ):
+                logging.info(
+                    f"action:spared pid:{pid} cmdline:{cmdline} matched:{b} allowed-by:<is-substring> source:{source.value}"
+                )
+                return
             try:
                 os.kill(pid, signal.SIGKILL)
                 logging.info(f"action:killed pid:{pid} cmdline:{cmdline} matched:{b} source:{source.value}")


### PR DESCRIPTION
A substring match is defined as a string with a alphanumeric or underscore character before or after the match.

Alternatively we could have two configured lists, one for substring matches (mostly useful for short strings as these are more likely to match with valid strings) and that behaves as at present.