### PR TITLE
Prometheus metrics can take an optional prefix (useful for dev)

### DIFF
--- a/cryptnono/templates/daemonset.yaml
+++ b/cryptnono/templates/daemonset.yaml
@@ -38,6 +38,13 @@ spec:
             {{- if .Values.detectors.execwhacker.metrics.enabled }}
             - --serve-metrics-port={{ .Values.detectors.execwhacker.metrics.port }}
             {{ end}}
+          {{- with .Values.detectors.execwhacker.env }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}

--- a/cryptnono/values.yaml
+++ b/cryptnono/values.yaml
@@ -51,6 +51,8 @@ detectors:
     enabled: true
     resources: {}
     configs: {}
+    # Optional environment variables
+    env: {}
     metrics:
       enabled: false
       port: 12121

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -52,8 +52,11 @@ class ProcessSource(Enum):
 # https://github.com/WojciechMula/pyahocorasick/issues/114
 banned_strings_automaton_lock = threading.Lock()
 
-processes_checked = Counter("cryptnono_execwhacker_processes_checked_total", "Total number of processes checked", ["source"])
-processes_killed = Counter("cryptnono_execwhacker_processes_killed_total", "Total number of processes killed", ["source"])
+# Optionally override this in development to avoid polluting real metrics
+cryptnono_metrics_prefix = os.getenv("CRYPTNONO_METRICS_PREFIX", "cryptnono")
+
+processes_checked = Counter(f"{cryptnono_metrics_prefix}_execwhacker_processes_checked_total", "Total number of processes checked", ["source"])
+processes_killed = Counter(f"{cryptnono_metrics_prefix}_execwhacker_processes_killed_total", "Total number of processes killed", ["source"])
 
 
 def kill_if_needed(banned_strings_automaton, allowed_patterns, cmdline, pid, source):


### PR DESCRIPTION
Useful for development/testing on a shared K8S cluster to avoid polluting production Prometheus metrics with test counts.